### PR TITLE
Update configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,8 @@ AC_PREREQ([2.61])
 AC_CONFIG_HEADERS(config.h)
 
 AM_INIT_AUTOMAKE([-Wall -Werror foreign nostdinc silent-rules])
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+LT_INIT
 AM_MAINTAINER_MODE
 
 AC_PROG_CC


### PR DESCRIPTION
Per similar error, I applied the same patch to configure.ac as as was done in:
https://github.com/vlm/asn1c/issues/62

After applying the patch, autorun.sh completes without error, and I'm able to compile. The resulting module appears to function as expected: able to load the module & connect to default.icb.net.